### PR TITLE
Possible mix myisam + innodb problem

### DIFF
--- a/digiid-authentication.php
+++ b/digiid-authentication.php
@@ -72,7 +72,6 @@ CREATE TABLE {$table_name_nonce} (
 	PRIMARY KEY (nonce),
 	KEY (birth)
 )
-ENGINE=InnoDB
 DEFAULT CHARSET=utf8
 COLLATE=utf8_bin
 SQL_BLOCK;
@@ -88,7 +87,6 @@ CREATE TABLE {$table_name_links} (
 	KEY (birth),
 	FOREIGN KEY (user_id) REFERENCES {$table_name_users}(ID)
 )
-ENGINE=InnoDB
 DEFAULT CHARSET=utf8
 COLLATE=utf8_bin
 SQL_BLOCK;


### PR DESCRIPTION
When installer of digi-id create tables, it uses "ENGINE=InnoDB" tag. but if the tables of wordpress have "ENGINE=MyISAM" (as on my server, for example) then table with foreign key to another table with another engine create fails. By this reason, MySQL can't create table "digiid_userlink" and plugin don't work correctly.

Reason: https://stackoverflow.com/questions/9018584/error-code-1005-cant-create-table-errno-150
Known cause 4.

Possible solution: dont specify engine, and leave engines "by default" (remove "ENGINE=InnoDB" in 75 and 91 lines)